### PR TITLE
move GoogleTest to CMake 

### DIFF
--- a/.github/workflows/efp_base_macos.yml
+++ b/.github/workflows/efp_base_macos.yml
@@ -12,9 +12,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Install GTest
-      run: brew install googletest
+    - uses: actions/checkout@v4
     - name: CMake set-up
       run: cmake -DCMAKE_BUILD_TYPE=Release .
     - name: make

--- a/.github/workflows/efp_base_ubuntu.yml
+++ b/.github/workflows/efp_base_ubuntu.yml
@@ -13,8 +13,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Install GTest
-      run: sudo apt install libgtest-dev
     - name: CMake set-up
       run: cmake -DCMAKE_BUILD_TYPE=Release .
     - name: make

--- a/.github/workflows/efp_base_win.yml
+++ b/.github/workflows/efp_base_win.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - name: Install gtest
       uses: MarkusJx/googletest-installer@v1.1
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: CMake set-up
       run: cmake -S . `-D CMAKE_BUILD_TYPE=Release -D GTEST_ROOT=D:/gtest`
     - name: make

--- a/.github/workflows/efp_base_win.yml
+++ b/.github/workflows/efp_base_win.yml
@@ -12,8 +12,6 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - name: Install gtest
-      uses: MarkusJx/googletest-installer@v1.1
     - uses: actions/checkout@v4
     - name: CMake set-up
       run: cmake -S . `-D CMAKE_BUILD_TYPE=Release -D GTEST_ROOT=D:/gtest`

--- a/.github/workflows/efp_base_win.yml
+++ b/.github/workflows/efp_base_win.yml
@@ -14,6 +14,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: CMake set-up
-      run: cmake -S . `-D CMAKE_BUILD_TYPE=Release -D GTEST_ROOT=D:/gtest`
+      run: cmake -S . `-D CMAKE_BUILD_TYPE=Release`
     - name: make
       run: cmake --build . --config Release

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,11 +23,6 @@ set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(googletest)
 enable_testing()
 
-if(WIN32)
-    set(CMAKE_CXX_FLAGS_RELEASE "/MT")
-    set(CMAKE_CXX_FLAGS_DEBUG "/MTd")
-endif()
-
 add_library(efp STATIC ElasticFrameProtocol.cpp)
 add_library(efp_shared SHARED ElasticFrameProtocol.cpp)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,16 @@ set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DDEBUG")
 #set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fprofile-arcs -ftest-coverage")
 
 find_package(Threads REQUIRED)
-find_package(GTest REQUIRED)
+
+set(gtest_force_shared_crt on)
+include(FetchContent)
+FetchContent_Declare(googletest
+        GIT_REPOSITORY https://github.com/google/googletest.git
+        GIT_TAG v1.16.0)
+# For Windows: Prevent overriding the parent project's compiler/linker settings
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(googletest)
+enable_testing()
 
 if(WIN32)
     set(CMAKE_CXX_FLAGS_RELEASE "/MT")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,6 @@ set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DDEBUG")
 
 find_package(Threads REQUIRED)
 
-set(gtest_force_shared_crt on)
 include(FetchContent)
 FetchContent_Declare(googletest
         GIT_REPOSITORY https://github.com/google/googletest.git


### PR DESCRIPTION
Moves the population of GoogleTest to CMake as recommended by Google 
https://google.github.io/googletest/quickstart-cmake.html
That simplifies the build actions 

This pull request also fixes the failing windows build. 